### PR TITLE
change mychannel.tx to $CHANNEL_NAME.tx

### DIFF
--- a/artifacts/channel/create-artifacts.sh
+++ b/artifacts/channel/create-artifacts.sh
@@ -21,7 +21,7 @@ configtxgen -profile OrdererGenesis -configPath . -channelID $SYS_CHANNEL  -outp
 
 
 # Generate channel configuration block
-configtxgen -profile BasicChannel -configPath . -outputCreateChannelTx ./mychannel.tx -channelID $CHANNEL_NAME
+configtxgen -profile BasicChannel -configPath . -outputCreateChannelTx ./$CHANNEL_NAME.tx -channelID $CHANNEL_NAME
 
 echo "#######    Generating anchor peer update for Org1MSP  ##########"
 configtxgen -profile BasicChannel -configPath . -outputAnchorPeersUpdate ./Org1MSPanchors.tx -channelID $CHANNEL_NAME -asOrg Org1MSP


### PR DESCRIPTION
The .tx file is hardcoded to be mychannel and throws an error if the channel name in the $CHANNEL_NAME is changed. So, generalized it to be used for other channel names as well.